### PR TITLE
Eliminación hogar y oficia, modif. styles de teams

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -321,6 +321,7 @@ header.headerFlotante .navBar li a:hover {
   color: white;
   font-size: 3em;
   font-weight: 400;
+  margin-top: 40px;
 }
 
 .tituloTeams span {
@@ -336,7 +337,7 @@ header.headerFlotante .navBar li a:hover {
 }
 
 .equipo .integrantes .box {
-  width: 440px;
+  width: 400px;
   margin: 20px;
   padding: 40px;
   background: white;
@@ -377,7 +378,7 @@ header.headerFlotante .navBar li a:hover {
   color: black;
   text-align: justify;
   font-weight: 200;
-  font-size: 1.3em;
+  font-size: 1.2em;
   margin-top: 5px;
 }
 

--- a/src/components/Cabecera.vue
+++ b/src/components/Cabecera.vue
@@ -9,8 +9,6 @@
                 <li><a href="#banner">Inicio</a></li>
                 <li><a href="#servicios">Servicios</a></li>
                 <li><a href="#noticias">Noticias</a></li>
-                <li><a href="#hogar">Hogar</a></li>
-                <li><a href="#oficina">Oficina</a></li>
                 <li><a href="#equipo">Nuestro Equipo</a></li>
             </ul>
 


### PR DESCRIPTION
Eliminé las secciones en el banner de hogar y oficina
del styles se modificó el tamaño de la letra del parrafo para los integrantes del equipo y su box